### PR TITLE
Update to your PR for notation data

### DIFF
--- a/openpgp/keys.go
+++ b/openpgp/keys.go
@@ -424,7 +424,10 @@ func addUserID(e *Entity, packets *packet.Reader, pkt *packet.UserId) error {
 			if err = e.PrimaryKey.VerifyUserIdSignature(pkt.Id, e.PrimaryKey, sig); err != nil {
 				return errors.StructuralError("user ID self-signature invalid: " + err.Error())
 			}
-			identity.SelfSignature = sig
+			if identity.SelfSignature == nil || sig.CreationTime.After(identity.SelfSignature.CreationTime) {
+				identity.SelfSignature = sig
+			}
+
 			e.Identities[pkt.Id] = identity
 		} else {
 			identity.Signatures = append(identity.Signatures, sig)

--- a/openpgp/packet/signature.go
+++ b/openpgp/packet/signature.go
@@ -57,7 +57,7 @@ type Signature struct {
 	PreferredSymmetric, PreferredHash, PreferredCompression []uint8
 	IssuerKeyId                                             *uint64
 	IsPrimaryId                                             *bool
-	NotationData                                            map[string]string
+	NotationData                                            map[string][]string
 
 	// FlagsValid is set if any flags were given. See RFC 4880, section
 	// 5.2.3.21 for details.
@@ -313,9 +313,9 @@ func parseSignatureSubpacket(sig *Signature, subpacket []byte, isHashed bool) (r
 		value := string(buf.Next(int(valueLength)))
 
 		if sig.NotationData == nil {
-			sig.NotationData = make(map[string]string)
+			sig.NotationData = make(map[string][]string)
 		}
-		sig.NotationData[key] = value
+		sig.NotationData[key] = append(sig.NotationData[key], value)
 	case prefHashAlgosSubpacket:
 		// Preferred hash algorithms, section 5.2.3.8
 		if !isHashed {


### PR DESCRIPTION
Hi, I did a little deep dive into adding this feature. I changed up the type to allow multiple values for the same key. Also, I found out that the `addUserID()` function only kept the last parsed self signature in the Identity struct. This means while the NotationData is getting parsed, it gets thrown away in a non-deterministic way. I added a check to keep the latest self sign. 

To demonstrate the code I have setup this playground: https://play.golang.org/p/1x9kWh7Jp7T